### PR TITLE
Add initial trading bot framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # ZEUS_BOT
-Automation of trading, in order to make 100k. 
+
+A framework for experimenting with high-frequency cryptocurrency trading using machine learning and reinforcement learning techniques.
+
+## Features
+
+- Fetches 5-minute OHLCV data from Binance.
+- Generates technical indicators for supervised learning.
+- Trains a gradient boosting classifier to predict short-term price direction.
+- Provides a simple PPO reinforcement learning environment for strategy optimisation.
+- Designed to maintain a positive risk–reward ratio with dynamic stop-loss and take-profit logic (to be implemented).
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Export required API keys as environment variables:
+
+- `BINANCE_API_KEY`
+- `BINANCE_SECRET_KEY`
+- `SANTIMENT_API_KEY` (optional)
+- `NEWS_API_KEY` (optional)
+- `CRYPTO_PANIC_API_KEY` (optional)
+- `REDDIT_CLIENT_ID` and `REDDIT_SECRET` (optional)
+
+3. Run the training pipeline:
+
+```bash
+python -m trading_bot.main
+```
+
+This will download recent market data, train the supervised model, and perform a short reinforcement learning session. Order execution logic should be added where indicated in `trading_bot/main.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+numpy
+scikit-learn
+stable-baselines3
+binance
+gym

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -1,0 +1,18 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class APIConfig:
+    binance_api_key: str = os.getenv("BINANCE_API_KEY", "")
+    binance_secret_key: str = os.getenv("BINANCE_SECRET_KEY", "")
+    santiment_key: str = os.getenv("SANTIMENT_API_KEY", "")
+    news_key: str = os.getenv("NEWS_API_KEY", "")
+    crypto_panic_key: str = os.getenv("CRYPTO_PANIC_API_KEY", "")
+    reddit_client_id: str = os.getenv("REDDIT_CLIENT_ID", "")
+    reddit_secret: str = os.getenv("REDDIT_SECRET", "")
+
+
+def load_config() -> APIConfig:
+    """Load API keys from environment variables."""
+    return APIConfig()

--- a/trading_bot/data.py
+++ b/trading_bot/data.py
@@ -1,0 +1,50 @@
+import logging
+from typing import List, Dict
+
+import pandas as pd
+from binance.client import Client
+
+from .config import load_config
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_klines(symbol: str, interval: str, limit: int = 500) -> pd.DataFrame:
+    """Fetch historical klines from Binance."""
+    cfg = load_config()
+    client = Client(cfg.binance_api_key, cfg.binance_secret_key)
+    raw = client.get_klines(symbol=symbol, interval=interval, limit=limit)
+    df = pd.DataFrame(
+        raw,
+        columns=[
+            "open_time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "quote_asset_volume",
+            "number_of_trades",
+            "taker_buy_base_volume",
+            "taker_buy_quote_volume",
+            "ignore",
+        ],
+    )
+    df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+    df["close_time"] = pd.to_datetime(df["close_time"], unit="ms")
+    df = df.astype(
+        {"open": float, "high": float, "low": float, "close": float, "volume": float}
+    )
+    return df
+
+
+def compute_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Generate features for the ML model."""
+    df = df.copy()
+    df["returns"] = df["close"].pct_change()
+    df["ma_fast"] = df["close"].rolling(window=5).mean()
+    df["ma_slow"] = df["close"].rolling(window=20).mean()
+    df["volatility"] = df["returns"].rolling(window=20).std()
+    df.dropna(inplace=True)
+    return df

--- a/trading_bot/evaluation.py
+++ b/trading_bot/evaluation.py
@@ -1,0 +1,16 @@
+import logging
+from typing import List
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_profit(trades: List[float]) -> float:
+    return float(np.sum(trades))
+
+
+def risk_reward_ratio(profits: List[float], losses: List[float]) -> float:
+    if not losses:
+        return float("inf")
+    return abs(np.mean(profits)) / abs(np.mean(losses))

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -1,0 +1,31 @@
+import logging
+
+import numpy as np
+
+from .data import fetch_klines, compute_features
+from .model import train_supervised_model
+from .rl_agent import train_rl_agent
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run(symbol: str = "BTCUSDT", interval: str = Client.KLINE_INTERVAL_5MINUTE):
+    df = fetch_klines(symbol, interval)
+    df = compute_features(df)
+
+    clf, accuracy = train_supervised_model(df)
+    logger.info("Trained supervised model with accuracy %.2f%%", accuracy * 100)
+
+    env_data = df[["close", "returns", "ma_fast", "ma_slow", "volatility"]].values
+    model = train_rl_agent(env_data)
+    logger.info("RL agent trained")
+
+    # Placeholder for live trading integration
+    logger.info("Trading bot setup complete. Implement order execution logic here.")
+
+
+if __name__ == "__main__":
+    from binance.client import Client
+
+    run()

--- a/trading_bot/model.py
+++ b/trading_bot/model.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Tuple
+
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import Pipeline
+
+logger = logging.getLogger(__name__)
+
+
+def train_supervised_model(data: pd.DataFrame) -> Tuple[Pipeline, float]:
+    """Train a simple classifier to predict next 5-minute return direction."""
+    df = data.copy()
+    df["target"] = (df["close"].shift(-1) > df["close"]).astype(int)
+    df.dropna(inplace=True)
+
+    features = ["returns", "ma_fast", "ma_slow", "volatility"]
+    X = df[features]
+    y = df["target"]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+    clf = Pipeline(
+        [("scaler", StandardScaler()), ("gbc", GradientBoostingClassifier())]
+    )
+    clf.fit(X_train, y_train)
+    score = clf.score(X_test, y_test)
+    logger.info("Supervised model accuracy: %.2f%%", score * 100)
+    return clf, score

--- a/trading_bot/rl_agent.py
+++ b/trading_bot/rl_agent.py
@@ -1,0 +1,57 @@
+import logging
+from typing import Any
+
+import gym
+import numpy as np
+from gym import spaces
+from stable_baselines3 import PPO
+
+logger = logging.getLogger(__name__)
+
+
+class TradingEnv(gym.Env):
+    """A simple trading environment for reinforcement learning."""
+
+    def __init__(self, data: np.ndarray, initial_balance: float = 1000.0):
+        super().__init__()
+        self.data = data
+        self.initial_balance = initial_balance
+        self.action_space = spaces.Discrete(3)  # 0: hold, 1: buy, 2: sell
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(data.shape[1],), dtype=np.float32
+        )
+        self.reset()
+
+    def reset(self):
+        self.balance = self.initial_balance
+        self.position = 0  # +1 for long, -1 for short
+        self.index = 0
+        return self.data[self.index]
+
+    def step(self, action: int):
+        done = False
+        reward = 0.0
+        if action == 1 and self.position == 0:
+            self.position = 1
+        elif action == 2 and self.position == 0:
+            self.position = -1
+        elif action == 0:
+            pass
+
+        self.index += 1
+        if self.index >= len(self.data) - 1:
+            done = True
+
+        price_change = self.data[self.index][0] - self.data[self.index - 1][0]
+        reward = self.position * price_change
+        obs = self.data[self.index]
+        return obs, reward, done, {}
+
+
+def train_rl_agent(data: np.ndarray, timesteps: int = 10000) -> PPO:
+    """Train a PPO agent on the trading environment."""
+    env = TradingEnv(data)
+    model = PPO("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=timesteps)
+    logger.info("RL agent training completed")
+    return model


### PR DESCRIPTION
## Summary
- add environment variable config loader
- fetch OHLC data from Binance and compute features
- train supervised model and RL agent
- include evaluation helpers
- document setup instructions

## Testing
- `black trading_bot`
- `python -m py_compile $(find trading_bot -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684050ac39548321a1fe03cdbddf5032